### PR TITLE
Add Seed Admin Roles to First Admin User

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,6 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 
-julia = AdminUser.create! do |a|
-            a.email       = 'julia@girldevelopit.com'
-            a.password    = a.password_confirmation = 'password'
-          end
-
 admin = Role.create! do |a|
                 a.name = 'admin'
                 a.resource_id = 1
@@ -16,6 +11,7 @@ leader = Role.create! do |a|
                 a.resource_id = 2
               end
 
+#give role privileges to default admin user created by Devise
 adminfirst = AdminUser.first
 adminfirst.roles << admin
 adminfirst.roles << leader


### PR DESCRIPTION
##### In our app, a default AdminUser is created in our first db migration, as templated by Devise:
https://github.com/GirlDevelopIt/gdi-new-site/blob/master/db/migrate/20140804204617_devise_create_admin_users.rb#L5


#### Before
##### Another AdminUser was created in the db seed data, and then assigned admin roles:
https://github.com/GirlDevelopIt/gdi-new-site/blob/master/db/seeds.rb#L19

#### After
##### With this pull request, we add the Rolify admin roles to the original default admin user and get the following results:

![gdi-new-site-dev](https://cloud.githubusercontent.com/assets/226228/5768097/b3a8f6b2-9cdb-11e4-989b-eb8d073e79b5.jpg)
![login___gdi_main_site](https://cloud.githubusercontent.com/assets/226228/5768093/b08c1694-9cdb-11e4-98a5-587ab48410cd.jpg)
![edit_admin_user___gdi_main_site](https://cloud.githubusercontent.com/assets/226228/5768095/b1b2a826-9cdb-11e4-9e42-4632020af7e3.jpg)

#### To Test
This can be tested in anyone's local environment by running `rake db:drop` followed by `rake db:create db:migrate db:seed` (you could also run `rake db:reset`, but the former matches what new users will experience more precisely)