### PR TITLE
Adding Mandrill smtp for sending reset password emails for Active Admin

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,18 +5,7 @@ Rails.application.configure do
 
    config.action_mailer.delivery_method = :smtp
    
-  # THIS IS SENDGRID
-  # config.action_mailer.smtp_settings = {
-  #   :user_name => 'kristen@girldevelopit.com',
-  #   :password => 'gc3CfScU)^?,64p',
-  #   :domain => 'girl-develop-it.herokuapp.com',
-  #   :address => 'smtp.sendgrid.net',
-  #   :port => 587,
-  #   :authentication => :plain,
-  #   :enable_starttls_auto => true
-  # }
-
-  # THIS IS MANDRILL
+  # Mandrill smtp settings
   config.action_mailer.smtp_settings = {
     :user_name => 'app28236699@heroku.com',
     :password => 'VblU43FdRCyahN_lqLBuMw',

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,7 +3,28 @@ Rails.application.configure do
 
    config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
+   config.action_mailer.delivery_method = :smtp
+   
+  # THIS IS SENDGRID
+  # config.action_mailer.smtp_settings = {
+  #   :user_name => 'kristen@girldevelopit.com',
+  #   :password => 'gc3CfScU)^?,64p',
+  #   :domain => 'girl-develop-it.herokuapp.com',
+  #   :address => 'smtp.sendgrid.net',
+  #   :port => 587,
+  #   :authentication => :plain,
+  #   :enable_starttls_auto => true
+  # }
 
+  # THIS IS MANDRILL
+  config.action_mailer.smtp_settings = {
+    :user_name => 'app28236699@heroku.com',
+    :password => 'VblU43FdRCyahN_lqLBuMw',
+    :address => 'smtp.mandrillapp.com',
+    :port => 587,
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'donotreply@girldevelopit.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Hooray for Mandrill! As noted in issue #100 , we'll want to verify our domain to improve deliverability, but we'll cross that bridge once we get there. Sendgrid config is commented out if anyone's curious to see the performance difference.