### PR TITLE
AA Bundle Install Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jquery-rails'
 # gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0',          group: :doc
-gem 'activeadmin', github: 'gregbell/active_admin'
+gem 'activeadmin', git: 'https://github.com/activeadmin/activeadmin.git'
 gem 'devise',  '~> 3.2.0'
 gem "font-awesome-rails"
 gem 'bourbon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/gregbell/active_admin.git
-  revision: 952273a204def082e0891cc94f1f8c15216605d0
+  remote: https://github.com/activeadmin/activeadmin.git
+  revision: b3a9f4b3e4051447d011c59649a73f876989a199
   specs:
     activeadmin (1.0.0.pre)
       arbre (~> 1.0, >= 1.0.2)
@@ -8,11 +8,11 @@ GIT
       coffee-rails
       formtastic (~> 3.1)
       formtastic_i18n
-      inherited_resources (~> 1.4, != 1.5.0)
+      inherited_resources (~> 1.6)
       jquery-rails
       jquery-ui-rails (~> 5.0)
       kaminari (~> 0.15)
-      rails (>= 3.2, < 4.2)
+      rails (>= 3.2, < 5.0)
       ransack (~> 1.3)
       sass-rails
 
@@ -46,7 +46,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    arbre (1.0.2)
+    arbre (1.0.3)
       activesupport (>= 3.0.0)
     arel (5.0.1.20140414130214)
     bcrypt (3.1.9)
@@ -158,7 +158,7 @@ GEM
     font-awesome-rails (4.2.0.0)
       railties (>= 3.2, < 5.0)
     formatador (0.2.5)
-    formtastic (3.1.2)
+    formtastic (3.1.3)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.1.1)
     friendly_id (5.0.4)
@@ -182,11 +182,11 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.6.11)
     inflecto (0.0.2)
-    inherited_resources (1.5.1)
-      actionpack (>= 3.2, < 4.2)
+    inherited_resources (1.6.0)
+      actionpack (>= 3.2, < 5)
       has_scope (~> 0.6.0.rc)
-      railties (>= 3.2, < 4.2)
-      responders (~> 1.0)
+      railties (>= 3.2, < 5)
+      responders
     ipaddress (0.8.0)
     jbuilder (2.2.5)
       activesupport (>= 3.0.0, < 5)
@@ -194,10 +194,10 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (5.0.2)
+    jquery-ui-rails (5.0.3)
       railties (>= 3.2.16)
     json (1.8.1)
-    kaminari (0.16.1)
+    kaminari (0.16.2)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.2)
@@ -271,7 +271,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.4.0)
-    ransack (1.5.1)
+    ransack (1.6.3)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
       activesupport (>= 3.0)


### PR DESCRIPTION
Swapping AA gem 'github' call (git://) with 'git' call so we can use https:// protocol when running bundle install