### PR TITLE
add context-linking to url links on code of conduct and add mailto links...

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -73,9 +73,9 @@
         <h2>Contact Us</h2>
       </div>
       <section class="contact">
-        <p class="large">For general inquiries: info@girldevelopit.com</p>
-        <p class="large">For partnership opportunities: partnerships@girldevelopit.com</p>
-        <p class="large">For sponsorships: sponsorships@girldevelopit.com</p>
+        <p class="large">For general inquiries: <a href="mailto:info@girldevelopit.com" >info@girldevelopit.com</a></p>
+        <p class="large">For partnership opportunities: <a href="mailto:partnerships@girldevelopit.com" >partnerships@girldevelopit.com</a></p>
+        <p class="large">For sponsorships: <a href="mailto:sponsorships@girldevelopit.com" >sponsorships@girldevelopit.com</a></p>
       </section>
 
 

--- a/app/views/home/code-of-conduct.html.erb
+++ b/app/views/home/code-of-conduct.html.erb
@@ -20,11 +20,11 @@
         <h3>Consequences Of Unacceptable Behavior</h3>
         <p>If a participant engages in harassing behavior, the Girl Develop It organizers may take any action they deem appropriate, including warning the offender or expelling him or her from the class/event/meetup group [with no refund]. </p><br>
         <h3>What To Do If You Witness Or Are Subject To Unacceptable Behavior</h3>
-        <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your local Chapter Leader(s) immediately. Contact information for your local Chapter Leader can be found on <%= link_to "#{root_url.chop!}#{chapters_path}", chapters_path %>.</p>
+        <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your local Chapter Leader(s) immediately. Contact information for your local Chapter Leader can be found on <%= link_to "our Chapters page", chapters_path %>.</p>
         <p>Girl Develop It Chapter Leaders/Teachers/Event Organizers will be happy to help members contact local law enforcement, provide escorts when possible and with reasonable notice, or otherwise assist those experiencing harassment to feel safe for the duration of the event/class. We value your attendance.</p>
         <p>Girl Develop It expects participants to follow these rules at all Girl Develop It social events and in online discourse.</p><br>
         <h3>Contact Information</h3>
-        <p>If you have any questions, please contact your local chapter. Contact information for your local Chapter Leader can be found at <%= link_to "#{root_url.chop!}#{chapters_path}", chapters_path %>.</p>
+        <p>If you have any questions, please contact your local chapter. Contact information for your local Chapter Leader can be found on <%= link_to "our Chapters page", chapters_path %>.</p>
     </section>
 
 


### PR DESCRIPTION
... on about page

Creates a context based link for the code of conduct page and adds the mailto links for the email addresses on the about page