### PR TITLE
Turn on SSL for issue #60.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
In preparation for issue #60, this setting can be enabled now.  When the app is deployed to heroku it will inherit the heroku SSL certificate until GDI sets up their own certificate.

In the meantime, it's good net citizen behavior to enable SSL by default in any public facing application.
