### PR TITLE
Fixing leader AA permissions

### DIFF
--- a/app/admin/bio.rb
+++ b/app/admin/bio.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Bio do
   # https://github.com/gregbell/active_admin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #
   permit_params :bio, :user, :title, :name, :info, :admin_user_id, :image,
-                :twitter, :email, :website, :linkedin, :github, :chapter_id
+                :twitter, :email, :website, :linkedin, :github, :chapter_id, :chapter
 
   show do |ad|
     attributes_table do
@@ -30,8 +30,15 @@ ActiveAdmin.register Bio do
 
   form(:html => { :multipart => true }) do |f|
     f.inputs "Edit Bio" do
-      f.input :admin_user
-      f.input :chapter, member_label: :chapter
+      #if user only has one role and it is leader...
+      if current_admin_user.roles.count == 1 and current_admin_user.roles.first.name == "leader"
+        #...then set the chapter_id to the leader's chapter_id
+        f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
+      else
+        #otherwise, admin can pick the chapter for the new bio using dropdown list :chapter
+        f.input :chapter, member_label: :chapter
+      end
+      #f.input :admin_user
       f.input :title, as: :select, collection: ['LEADERS', 'INSTRUCTORS', 'VOLUNTEERS']
       f.input :name, placeholder: "Jane Doe"
       f.input :email, placeholder: current_admin_user.email

--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Sponsor do
   # See permitted parameters documentation:
   # https://github.com/gregbell/active_admin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #
-  permit_params :sponsor, :name, :url, :name, :chapter_id, :image
+  permit_params :sponsor, :name, :url, :name, :chapter, :chapter_id, :image
 
   show do |ad|
     attributes_table do
@@ -20,8 +20,15 @@ ActiveAdmin.register Sponsor do
   end
 
   form(:html => { :multipart => true }) do |f|
-    f.inputs "Edit Sponsor" do
-      f.input :chapter, member_label: :chapter
+  f.inputs "Edit Sponsor" do
+      #if user only has one role and it is leader...
+      if current_admin_user.roles.count == 1 and current_admin_user.roles.first.name == "leader"
+        #...then set the chapter_id to the leader's chapter_id
+        f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
+      else
+        #otherwise, admin can pick the chapter for the new sponsor using dropdown list :chapter
+        f.input :chapter, member_label: :chapter
+      end
       f.input :name, placeholder: "The Iron Yard"
       f.input :url, placeholder: "http://www.theironyard.com"
       f.input :image

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,10 +9,23 @@ class Ability
     if allroles.include? "admin"
       can :manage, :all
     elsif allroles.include? "leader"
-      can :manage, user.chapter
-      can :manage, user.bio
-      can :manage, Sponsor
-      can :read, :all
+      #allow view of Dashboard page
+      can :read, ActiveAdmin::Page, name: 'Dashboard'
+
+      #leader can only view/update chapter details (not create)
+      can [:read, :view, :manage], Chapter, :id => user.chapter_id
+     
+      #only list/manage the bios and sponsors related leader's chapter
+      can [:manage, :read, :view], [Bio, Sponsor], :chapter_id => user.chapter_id
+
+      #leader can create new bios and sponsors, but chapter_id is hidden in form
+      can :create, [Bio, Sponsor]
+
+      #leaders cannot create new chapters
+      cannot :create, Chapter
+
+      #leaders cannot view adminuser page
+      cannot :read, AdminUser
     else
       can :view, :all
     end


### PR DESCRIPTION
Automatically tying leaders to their own chapter ID to simplify the admin process for them.