### PR TITLE
Fixing alphabetical order of cities in chapter view

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,7 +1,8 @@
 class ChaptersController < ApplicationController
   require 'rails_autolink'
   def index
-    @chapters = Chapter.all
+    @chapters = Chapter.order("chapter ASC").all
+    p @chapters
     states = {}
     @chapters.each do |l|
       if states[l.state]
@@ -10,6 +11,8 @@ class ChaptersController < ApplicationController
         states[l.state] = [l.chapter]
       end
     end
+
+    #@states = states.to_a.sort
     @states = states.to_a.sort
 
   respond_to do |format|

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -2,7 +2,6 @@ class ChaptersController < ApplicationController
   require 'rails_autolink'
   def index
     @chapters = Chapter.order("chapter ASC").all
-    p @chapters
     states = {}
     @chapters.each do |l|
       if states[l.state]
@@ -11,8 +10,6 @@ class ChaptersController < ApplicationController
         states[l.state] = [l.chapter]
       end
     end
-
-    #@states = states.to_a.sort
     @states = states.to_a.sort
 
   respond_to do |format|


### PR DESCRIPTION
Opted for ordering the chapters by name in the controller. Pulls them in alphabetical order for looping on the chapter page.