### PR TITLE
Removing animate.css from imports and console chatter, fixes #232

### DIFF
--- a/app/assets/javascripts/chapter_map.js
+++ b/app/assets/javascripts/chapter_map.js
@@ -14,7 +14,6 @@ $(document).ready(function(){
 			}
 			plots.push(newobj);
 		})
-		console.log("yey!");
 	}).done(function () {
 		$(".us_map").mapael({
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -3,7 +3,6 @@
 @import "bourbon";
 @import "neat";
 @import "font-awesome";
-@import "animate.css";
 @import "base.css.scss";
 @import "typography.css.scss";
 @import "layout.css.scss";


### PR DESCRIPTION
animate.css.scss has been in the css import list so I'm removing animate.css to stop the console errors