### PR TITLE
mobile display of sponsors in chapter view, fixes issue #284

### DIFF
--- a/app/assets/stylesheets/state.css.scss
+++ b/app/assets/stylesheets/state.css.scss
@@ -67,8 +67,11 @@
 		.state-container-aside{
 			margin-top: -20px;
 		}
-		.button{
-			margin-bottom: 50px;
+		.sponsors {
+			margin-top: -20px;
+			img {
+				width: 30%;
+			}
 		}
 	}
 

--- a/app/assets/stylesheets/state.css.scss
+++ b/app/assets/stylesheets/state.css.scss
@@ -71,6 +71,7 @@
 			margin-top: -20px;
 			img {
 				width: 30%;
+				vertical-align: middle;
 			}
 		}
 	}

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -14,7 +14,6 @@
       <%= link_to "{ Join Us }", "http://www.meetup.com/#{@chapter.meetup}", :class=>"button" %>
 
       <% if @chapter.sponsors.count != 0 %>
-        <div class="hide">
           <div class="sponsors">
             <h2>Sponsors</h2>
             <div class="logos">
@@ -29,7 +28,6 @@
               <% end %>
             </div>
           </div>
-        </div>
       <% end %>
     </aside>
 


### PR DESCRIPTION
Here's a fix for [#284](https://github.com/girldevelopit/gdi-new-site/issues/284).

I've deleted the "hide" class, deleted a now unnecessary lower margin, and added mobile-only width for sponsor images.

Please let me know if this works, or if any other changes are on the wishlist for this one.

:heart: 